### PR TITLE
rebalance event triggers key group re-partioning initial

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -133,6 +133,17 @@ public class PipelineOptions {
 				" analyze as POJO. In some cases this might be preferable. For example, when using interfaces" +
 				" with subclasses that cannot be analyzed as POJO.");
 
+	public static final ConfigOption<Boolean> USE_DYNAMIC_PARTITIONING =
+		key("pipeline.use-dynamic-partitioning")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription("If enabled, uses dynamic key partitioning using RepartitionTaskEvent");
+
+	public static final ConfigOption<Long> EVENT_DISPATCHING_INTERVAL =
+		key("pipeline.event-dispatching-interval")
+			.defaultValue(0L)
+			.withDescription("Event dispatching interval");
+
 	public static final ConfigOption<Boolean> GENERIC_TYPES =
 		key("pipeline.generic-types")
 			.booleanType()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/RepartitionTaskEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/RepartitionTaskEvent.java
@@ -1,0 +1,74 @@
+package org.apache.flink.runtime.io.network.api;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+import java.io.IOException;
+
+/**
+ * This class provides a simple implementation of an event that holds an integer value.
+ */
+public class RepartitionTaskEvent extends RuntimeEvent {
+
+	/**
+	 * The integer value transported by this integer task event.
+	 */
+	private int value = -1;
+
+	/**
+	 * Default constructor (should only be used for deserialization).
+	 */
+	public RepartitionTaskEvent() {
+		// default constructor implementation.
+		// should only be used for deserialization
+	}
+
+	/**
+	 * Constructs a new integer task event.
+	 *
+	 * @param value the integer value to be transported inside this integer task event
+	 */
+	public RepartitionTaskEvent(final int value) {
+		this.value = value;
+	}
+
+	/**
+	 * Returns the stored integer value.
+	 *
+	 * @return the stored integer value or <code>-1</code> if no value has been set
+	 */
+	public int getInteger() {
+		return this.value;
+	}
+
+	@Override
+	public void write(final DataOutputView out) throws IOException {
+		out.writeInt(this.value);
+	}
+
+	@Override
+	public void read(final DataInputView in) throws IOException {
+		this.value = in.readInt();
+	}
+
+	@Override
+	public int hashCode() {
+
+		return this.value;
+	}
+
+	@Override
+	public boolean equals(final Object obj) {
+
+		if (!(obj instanceof RepartitionTaskEvent)) {
+			return false;
+		}
+
+		final RepartitionTaskEvent taskEvent = (RepartitionTaskEvent) obj;
+
+		return (this.value == taskEvent.getInteger());
+	}
+}
+
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelector.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
 
 /**
  * The {@link ChannelSelector} determines to which logical channels a record
@@ -53,4 +54,6 @@ public interface ChannelSelector<T extends IOReadableWritable> {
 	 * @return true if the selector is for broadcast mode.
 	 */
 	boolean isBroadcast();
+
+	void handleEvent(AbstractEvent event);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -66,6 +66,8 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 	@VisibleForTesting
 	public static final String DEFAULT_OUTPUT_FLUSH_THREAD_NAME = "OutputFlusher";
 
+	public final String taskName;
+
 	private static final Logger LOG = LoggerFactory.getLogger(RecordWriter.class);
 
 	private final ResultPartitionWriter targetPartition;
@@ -109,6 +111,8 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 			outputFlusher = new OutputFlusher(threadName, timeout);
 			outputFlusher.start();
 		}
+
+		this.taskName = taskName;
 	}
 
 	protected void emit(T record, int targetChannel) throws IOException, InterruptedException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RoundRobinChannelSelector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RoundRobinChannelSelector.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.api.writer;
 
 import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
 
 /**
  * This is the default implementation of the {@link ChannelSelector} interface. It represents a simple round-robin
@@ -49,4 +50,7 @@ public class RoundRobinChannelSelector<T extends IOReadableWritable> implements 
 	public boolean isBroadcast() {
 		return false;
 	}
+
+	@Override
+	public void handleEvent(AbstractEvent event) { }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputEmitter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputEmitter.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.operators.shipping;
 import org.apache.flink.api.common.distributions.DataDistribution;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.typeutils.TypeComparator;
+import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.util.MathUtils;
@@ -162,8 +163,11 @@ public class OutputEmitter<T> implements ChannelSelector<SerializationDelegate<T
 			return false;
 		}
 	}
-	
-	// --------------------------------------------------------------------------------------------
+
+    @Override
+    public void handleEvent(AbstractEvent event) { }
+
+    // --------------------------------------------------------------------------------------------
 
 	private int forward() {
 		return 0;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -69,11 +69,14 @@ import org.apache.flink.streaming.api.windowing.triggers.PurgingTrigger;
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
+import org.apache.flink.streaming.runtime.partitioner.DynamicKeyedFixedPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -132,7 +135,9 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 			dataStream,
 			new PartitionTransformation<>(
 				dataStream.getTransformation(),
-				new KeyGroupStreamPartitioner<>(keySelector, StreamGraphGenerator.DEFAULT_LOWER_BOUND_MAX_PARALLELISM)),
+				dataStream.getExecutionConfig().getUseDynamicPartitioning()?
+					new DynamicKeyedFixedPartitioner<>(keySelector, StreamGraphGenerator.DEFAULT_LOWER_BOUND_MAX_PARALLELISM):
+					new KeyGroupStreamPartitioner<>(keySelector, StreamGraphGenerator.DEFAULT_LOWER_BOUND_MAX_PARALLELISM)),
 			keySelector,
 			keyType);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -43,6 +43,7 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.transformations.ShuffleMode;
+import org.apache.flink.streaming.runtime.partitioner.DynamicFixedPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.RebalancePartitioner;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
@@ -551,7 +552,10 @@ public class StreamGraph implements Pipeline {
 			if (partitioner == null && upstreamNode.getParallelism() == downstreamNode.getParallelism()) {
 				partitioner = new ForwardPartitioner<Object>();
 			} else if (partitioner == null) {
-				partitioner = new RebalancePartitioner<Object>();
+				if (getExecutionConfig().getUseDynamicPartitioning())
+				partitioner = getExecutionConfig().getUseDynamicPartitioning()?
+					new DynamicFixedPartitioner<Object>():
+					new RebalancePartitioner<Object>();
 			}
 
 			if (partitioner instanceof ForwardPartitioner) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -156,6 +156,10 @@ public class RecordWriterOutput<OUT> implements OperatorChain.WatermarkGaugeExpo
 		recordWriter.flushAll();
 	}
 
+	public RecordWriter<SerializationDelegate<StreamElement>> getRecordWriter(){
+		return recordWriter;
+	}
+
 	@Override
 	public void close() {
 		recordWriter.close();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -104,7 +104,8 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 					inputSerializers[i],
 					ioManager,
 					new StatusWatermarkValve(checkpointedInputGates[i].getNumberOfInputChannels(), dataOutput),
-					i));
+					i,
+					operatorChain));
 		}
 
 		this.operatorChain = checkNotNull(operatorChain);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -73,8 +73,6 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
-	protected static final Logger LOG = LoggerFactory.getLogger(StreamTaskNetworkInput.class);
-
 	private final CheckpointedInputGate checkpointedInputGate;
 
 	private final DeserializationDelegate<StreamElement> deserializationDelegate;
@@ -117,7 +115,6 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 		this.inputIndex = inputIndex;
 		this.channelIndexes = getChannelIndexes(checkpointedInputGate);
 		this.operatorChain = chain;
-		LOG.info("StreamTaskNetworkInput init  inputIndex {} operator {}", inputIndex, chain.toString());
 	}
 
 	@Nonnull
@@ -187,7 +184,6 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 	}
 
 	private void processElement(StreamElement recordOrMark, DataOutput<T> output) throws Exception {
-		LOG.trace("StreamTaskNetworkInput processElement record {} tid {}:{}", recordOrMark, Thread.currentThread().getId(), Thread.currentThread().getName());
 		if (recordOrMark.isRecord()){
 			output.emitRecord(recordOrMark.asRecord());
 		} else if (recordOrMark.isWatermark()) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
-import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer;
 import org.apache.flink.runtime.io.network.api.serialization.RecordDeserializer.DeserializationResult;
 import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
@@ -41,6 +40,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -69,6 +73,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
+	protected static final Logger LOG = LoggerFactory.getLogger(StreamTaskNetworkInput.class);
+
 	private final CheckpointedInputGate checkpointedInputGate;
 
 	private final DeserializationDelegate<StreamElement> deserializationDelegate;
@@ -86,13 +92,16 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 
 	private RecordDeserializer<DeserializationDelegate<StreamElement>> currentRecordDeserializer = null;
 
+	private final OperatorChain operatorChain;
+
 	@SuppressWarnings("unchecked")
 	public StreamTaskNetworkInput(
 			CheckpointedInputGate checkpointedInputGate,
 			TypeSerializer<?> inputSerializer,
 			IOManager ioManager,
 			StatusWatermarkValve statusWatermarkValve,
-			int inputIndex) {
+			int inputIndex,
+			OperatorChain chain) {
 		this.checkpointedInputGate = checkpointedInputGate;
 		this.deserializationDelegate = new NonReusingDeserializationDelegate<>(
 			new StreamElementSerializer<>(inputSerializer));
@@ -107,6 +116,8 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 		this.statusWatermarkValve = checkNotNull(statusWatermarkValve);
 		this.inputIndex = inputIndex;
 		this.channelIndexes = getChannelIndexes(checkpointedInputGate);
+		this.operatorChain = chain;
+		LOG.info("StreamTaskNetworkInput init  inputIndex {} operator {}", inputIndex, chain.toString());
 	}
 
 	@Nonnull
@@ -126,7 +137,8 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 		TypeSerializer<?> inputSerializer,
 		StatusWatermarkValve statusWatermarkValve,
 		int inputIndex,
-		RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers) {
+		RecordDeserializer<DeserializationDelegate<StreamElement>>[] recordDeserializers,
+		OperatorChain operatorChain) {
 
 		this.checkpointedInputGate = checkpointedInputGate;
 		this.deserializationDelegate = new NonReusingDeserializationDelegate<>(
@@ -135,6 +147,7 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 		this.statusWatermarkValve = statusWatermarkValve;
 		this.inputIndex = inputIndex;
 		this.channelIndexes = getChannelIndexes(checkpointedInputGate);
+		this.operatorChain = operatorChain;
 	}
 
 	@Override
@@ -174,6 +187,7 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 	}
 
 	private void processElement(StreamElement recordOrMark, DataOutput<T> output) throws Exception {
+		LOG.trace("StreamTaskNetworkInput processElement record {} tid {}:{}", recordOrMark, Thread.currentThread().getId(), Thread.currentThread().getName());
 		if (recordOrMark.isRecord()){
 			output.emitRecord(recordOrMark.asRecord());
 		} else if (recordOrMark.isWatermark()) {
@@ -201,13 +215,7 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 			// Event received
 			final AbstractEvent event = bufferOrEvent.getEvent();
 			// TODO: with checkpointedInputGate.isFinished() we might not need to support any events on this level.
-			if (event.getClass() != EndOfPartitionEvent.class) {
-				throw new IOException("Unexpected event: " + event);
-			}
-
-			// release the record deserializer immediately,
-			// which is very valuable in case of bounded stream
-			releaseDeserializer(channelIndexes.get(bufferOrEvent.getChannelInfo()));
+			operatorChain.handleTaskEvent(event);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -112,13 +112,15 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 			inputSerializer1,
 			ioManager,
 			new StatusWatermarkValve(checkpointedInputGates[0].getNumberOfInputChannels(), output1),
-			0);
+			0,
+			operatorChain);
 		this.input2 = new StreamTaskNetworkInput<>(
 			checkpointedInputGates[1],
 			inputSerializer2,
 			ioManager,
 			new StatusWatermarkValve(checkpointedInputGates[1].getNumberOfInputChannels(), output2),
-			1);
+			1,
+			operatorChain);
 
 		this.operatorChain = checkNotNull(operatorChain);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitioner.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
@@ -44,7 +45,10 @@ public class BroadcastPartitioner<T> extends StreamPartitioner<T> {
 		return true;
 	}
 
-	@Override
+    @Override
+    public void handleEvent(AbstractEvent event) { }
+
+    @Override
 	public StreamPartitioner<T> copy() {
 		return this;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/DynamicFixedPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/DynamicFixedPartitioner.java
@@ -1,0 +1,63 @@
+package org.apache.flink.streaming.runtime.partitioner;
+
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.RepartitionTaskEvent;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.apache.flink.util.XORShiftRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+public class DynamicFixedPartitioner<T> extends StreamPartitioner<T> implements ConfigurableStreamPartitioner {
+	protected static final Logger LOG = LoggerFactory.getLogger(DynamicFixedPartitioner.class);
+
+	//	private int nextChannelToSendTo;
+	private int nextChannelToSendTo = 0;
+
+	private int maxParallelism = 0;
+
+	protected final Random rng = new XORShiftRandom();
+
+	@Override
+	public StreamPartitioner<T> copy() { return this; }
+
+	/**
+	 * Returns the logical channel index, to which the given record should be written. It is
+	 * illegal to call this method for broadcast channel selectors and this method can remain
+	 * not implemented in that case (for example by throwing {@link UnsupportedOperationException}).
+	 *
+	 * @param record the record to determine the output channels for.
+	 * @return an integer number which indicates the index of the output
+	 * channel through which the record shall be forwarded.
+	 */
+	@Override
+	public int selectChannel(SerializationDelegate<StreamRecord<T>> record) {
+		return nextChannelToSendTo;
+	}
+
+	/**
+	 * Configure the {@link StreamPartitioner} with the maximum parallelism of the down stream
+	 * operator.
+	 *
+	 * @param maxParallelism Maximum parallelism of the down stream operator.
+	 */
+	@Override
+	public void configure(int maxParallelism) {
+		this.maxParallelism = maxParallelism;
+	}
+
+	@Override
+	public void handleEvent(AbstractEvent event) {
+		nextChannelToSendTo = ((RepartitionTaskEvent)event).getInteger();
+		LOG.debug("DynamicFixedPartitioner handleEvent RepartitionTaskEvent {}", nextChannelToSendTo);
+	}
+
+	@Override
+	public String toString() {
+		return "DYNAMICFIXED";
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/DynamicKeyedFixedPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/DynamicKeyedFixedPartitioner.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.partitioner;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.api.RepartitionTaskEvent;
+import org.apache.flink.runtime.plugable.SerializationDelegate;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.XORShiftRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+/**
+ * Partitioner that distributes the data equally by cycling through the output
+ * channels.
+ *
+ * @param <T> Type of the elements in the Stream being rebalanced
+ */
+@Internal
+public class DynamicKeyedFixedPartitioner<T, K> extends StreamPartitioner<T> implements ConfigurableStreamPartitioner {
+	protected static final Logger LOG = LoggerFactory.getLogger(DynamicKeyedFixedPartitioner.class);
+
+	private static final long serialVersionUID = 1L;
+
+	//	private int nextChannelToSendTo;
+	private int nextChannelToSendTo = 0;
+
+	private int maxParallelism = 0;
+
+	private final KeySelector<T, K> keySelector;
+
+	protected final Random rng = new XORShiftRandom();
+
+	public DynamicKeyedFixedPartitioner(KeySelector<T, K> keySelector, int maxParallelism) {
+		Preconditions.checkArgument(maxParallelism > 0, "Number of key-groups must be > 0!");
+		this.keySelector = Preconditions.checkNotNull(keySelector);
+		this.maxParallelism = maxParallelism;
+	}
+
+	@Override
+	public void setup(int numberOfChannels) {
+		super.setup(numberOfChannels);
+	}
+
+	@Override
+	public int selectChannel(SerializationDelegate<StreamRecord<T>> record) {
+		return nextChannelToSendTo;
+	}
+
+	public StreamPartitioner<T> copy() {
+		return this;
+	}
+
+	@Override
+	public String toString() {
+		return "DYNAMICKEYEDFIXED";
+	}
+
+	@Override
+	public void handleEvent(AbstractEvent event) {
+		nextChannelToSendTo = ((RepartitionTaskEvent)event).getInteger();
+		LOG.debug("DynamicKeyedFixedPartitioner handleEvent RepartitionTaskEvent {}", nextChannelToSendTo);
+	}
+	/**
+	 * Configure the {@link StreamPartitioner} with the maximum parallelism of the down stream
+	 * operator.
+	 *
+	 * @param maxParallelism Maximum parallelism of the down stream operator.
+	 */
+	@Override
+	public void configure(int maxParallelism) {
+		this.maxParallelism = maxParallelism;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -42,6 +43,11 @@ public abstract class StreamPartitioner<T> implements
 	@Override
 	public boolean isBroadcast() {
 		return false;
+	}
+
+	@Override
+	public void handleEvent(AbstractEvent event) {
+
 	}
 
 	public abstract StreamPartitioner<T> copy();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -128,7 +128,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			inSerializer,
 			getEnvironment().getIOManager(),
 			statusWatermarkValve,
-			0);
+			0,
+			operatorChain);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -312,6 +312,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 
 		this.channelIOExecutor = Executors.newSingleThreadExecutor(new ExecutorThreadFactory("channel-state-unspilling"));
+		LOG.info("StreamTask init {} {} {}", this, inputProcessor, this.getClass());
 	}
 
 	private CompletableFuture<Void> prepareInputSnapshot(ChannelStateWriter channelStateWriter, long checkpointId) throws IOException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -312,7 +312,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 
 		this.channelIOExecutor = Executors.newSingleThreadExecutor(new ExecutorThreadFactory("channel-state-unspilling"));
-		LOG.info("StreamTask init {} {} {}", this, inputProcessor, this.getClass());
 	}
 
 	private CompletableFuture<Void> prepareInputSnapshot(ChannelStateWriter channelStateWriter, long checkpointId) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -174,7 +174,8 @@ public class StreamTaskNetworkInputTest {
 			LongSerializer.INSTANCE,
 			new StatusWatermarkValve(inputGate.getNumberOfInputChannels(), new NoOpDataOutput<>()),
 			inputGate.getGateIndex(),
-			createDeserializers(inputGate.getNumberOfInputChannels()));
+			createDeserializers(inputGate.getNumberOfInputChannels()),
+			null);
 	}
 
 	private TestRecordDeserializer[] createDeserializers(int numberOfInputChannels) {
@@ -204,7 +205,8 @@ public class StreamTaskNetworkInputTest {
 			inSerializer,
 			new StatusWatermarkValve(numInputChannels, output),
 			0,
-			deserializers);
+			deserializers,
+			null);
 
 		inputGate.sendEvent(
 			new CheckpointBarrier(checkpointId, 0L, CheckpointOptions.forCheckpointWithDefaultLocation()),
@@ -247,7 +249,8 @@ public class StreamTaskNetworkInputTest {
 			inSerializer,
 			new StatusWatermarkValve(1, output),
 			0,
-			deserializers);
+			deserializers,
+			null);
 
 		for (int i = 0; i < numInputChannels; i++) {
 			assertNotNull(deserializers[i]);
@@ -275,7 +278,8 @@ public class StreamTaskNetworkInputTest {
 			LongSerializer.INSTANCE,
 			ioManager,
 			new StatusWatermarkValve(1, output),
-			0);
+			0,
+			null);
 	}
 
 	private void serializeRecord(long value, BufferBuilder bufferBuilder) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -174,8 +174,7 @@ public class StreamTaskNetworkInputTest {
 			LongSerializer.INSTANCE,
 			new StatusWatermarkValve(inputGate.getNumberOfInputChannels(), new NoOpDataOutput<>()),
 			inputGate.getGateIndex(),
-			createDeserializers(inputGate.getNumberOfInputChannels()),
-			null);
+			createDeserializers(inputGate.getNumberOfInputChannels()), null);
 	}
 
 	private TestRecordDeserializer[] createDeserializers(int numberOfInputChannels) {
@@ -205,8 +204,7 @@ public class StreamTaskNetworkInputTest {
 			inSerializer,
 			new StatusWatermarkValve(numInputChannels, output),
 			0,
-			deserializers,
-			null);
+			deserializers, null);
 
 		inputGate.sendEvent(
 			new CheckpointBarrier(checkpointId, 0L, CheckpointOptions.forCheckpointWithDefaultLocation()),
@@ -249,8 +247,7 @@ public class StreamTaskNetworkInputTest {
 			inSerializer,
 			new StatusWatermarkValve(1, output),
 			0,
-			deserializers,
-			null);
+			deserializers, null);
 
 		for (int i = 0; i < numInputChannels; i++) {
 			assertNotNull(deserializers[i]);
@@ -278,8 +275,7 @@ public class StreamTaskNetworkInputTest {
 			LongSerializer.INSTANCE,
 			ioManager,
 			new StatusWatermarkValve(1, output),
-			0,
-			null);
+			0, null);
 	}
 
 	private void serializeRecord(long value, BufferBuilder bufferBuilder) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmark.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io.benchmark;
 
 import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.writer.ChannelSelector;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 
@@ -61,5 +62,8 @@ public class DataSkewStreamNetworkThroughputBenchmark extends StreamNetworkThrou
 		public boolean isBroadcast() {
 			return false;
 		}
-	}
+
+        @Override
+        public void handleEvent(AbstractEvent event) { }
+    }
 }


### PR DESCRIPTION
- ExecutionConfig (`pipeline.use-dynamic-partitioning`, `pipeline.event-dispatching-interval`)
- `handleEvent ` in `ChannelSelector`
- dynamic channel selector: StreamGraph, KeyedStream 
- event dispatcher in StreamSource
- operatorChain in StreamInputProcessor